### PR TITLE
fix(examples): adapt test extension in example to match API guidelines

### DIFF
--- a/api-guidelines/async/format/test-extension/rules/may-use-test-extension.md
+++ b/api-guidelines/async/format/test-extension/rules/may-use-test-extension.md
@@ -23,7 +23,7 @@ This extension defines the `test` context attribute that event producers can pro
     - `End2EndTest` Automatically created test events to test specific business cases within multiple teams.
     - `ManualTest` Manually created test events.
 - Examples:
-  - `kraken-sales-order-management.performancetest`
+  - `kraken-sales-order-management.PerformanceTest`
 - Constraints:
   - OPTIONAL
   - MUST be a non-empty string in the format `<test-scope>.<test-type>`.

--- a/dev-context/async/comparison-cef-cloudevents.md
+++ b/dev-context/async/comparison-cef-cloudevents.md
@@ -86,7 +86,7 @@ ce_specversion: "1.0"
 ce_traceparent: "00-5ad4298a6e154128ad80d59dd724aa60-00f067aa0ba902b7-00"
 ce_sequencetype: "Integer"
 ce_sequence: "25"
-ce_test: "OrderGenerationTest.Kraken"
+ce_test: "Kraken.OrderGenerationTest"
 content-type: "application/json;charset=utf-8"
 ```
 
@@ -119,7 +119,7 @@ ce-time: 2022-06-15T15:03:29.749+0000
 ce-traceparent: 00-5ad4298a6e154128ad80d59dd724aa60-00f067aa0ba902b7-00
 ce_sequencetype: Integer
 ce_sequence: 25
-ce-test: OrderGenerationTest.Kraken
+ce-test: Kraken.OrderGenerationTest
 Content-Type: application/json; charset=utf-8
 
 {
@@ -148,7 +148,7 @@ Representation in structured content mode
   "traceparent": "00-5ad4298a6e154128ad80d59dd724aa60-00f067aa0ba902b7-00",
   "sequencetype": "Integer",
   "sequence": "25",
-  "test": "OrderGenerationTest.Kraken",
+  "test": "Kraken.OrderGenerationTest",
   "data": {
     "transactionId": "c82fea59-f4d5-4712-bbc3-06a4e9eb14a6",
     "paymentReference": {


### PR DESCRIPTION
Changelog:

### Update

- Adapted test-type in example to match description [R200021](https://api.otto.de/portal/guidelines/r200021).
- Adapted test extension in comparison examples to match API guidelines [R200021](https://api.otto.de/portal/guidelines/r200021).