### PR TITLE
feat(docs): Rename customerId header according to RFC6648

### DIFF
--- a/api-guidelines/global/json/identifiers/rules/should-use-customerid-to-identify-customers.md
+++ b/api-guidelines/global/json/identifiers/rules/should-use-customerid-to-identify-customers.md
@@ -6,7 +6,7 @@ id: R100078
 
 The `customerId` is the recommended way to identify logged in customers. It replaces the `ec-uuid`.
 
-In HTTP headers, the `customerId` should be named consistently `X-Customer-Id`.
+In HTTP headers, the `customerId` should be named consistently `Customer-Id`.
 
 ::: warning Important
 For the time being, the `sub`-claim of the JWT still contains the `ec-uuid` for tokens granted through the [authorization code grant flow](../../../../rest/authorization/oauth/rules/must-use-authorization-grant.md).


### PR DESCRIPTION
Changelog:

### Update

- Aligned the customerId header name in rule "SHOULD use customerId to identify customers [R100078](https://api.otto.de/portal/guidelines/r100078)" to follow the deprecation of `X-`prefixes according RFC6648.
