### PR TITLE
feat(docs): Clarify that the customerId is now in the sub claim

### DIFF
--- a/api-guidelines/global/json/identifiers/rules/should-use-customerid-to-identify-customers.md
+++ b/api-guidelines/global/json/identifiers/rules/should-use-customerid-to-identify-customers.md
@@ -9,8 +9,7 @@ The `customerId` is the recommended way to identify logged in customers. It repl
 In HTTP headers, the `customerId` should be named consistently `X-Customer-Id`.
 
 ::: warning Important
-Tokens granted through the [authorization code grant flow](../../../../rest/authorization/oauth/rules/must-use-authorization-grant.md) 
-containing the customerId in the `sub`-claim.
+Tokens granted through the [authorization code grant flow](../../../../rest/authorization/oauth/rules/must-use-authorization-grant.md) contain the customerId in the `sub`-claim.
 
 An example is provided in the [OAuth2 section](../../../../rest/authorization/README.md#oauth-2-0).
 :::

--- a/api-guidelines/global/json/identifiers/rules/should-use-customerid-to-identify-customers.md
+++ b/api-guidelines/global/json/identifiers/rules/should-use-customerid-to-identify-customers.md
@@ -9,7 +9,8 @@ The `customerId` is the recommended way to identify logged in customers. It repl
 In HTTP headers, the `customerId` should be named consistently `X-Customer-Id`.
 
 ::: warning Important
-For the time being, the `sub`-claim of the JWT still contains the `ec-uuid` for tokens granted through the [authorization code grant flow](../../../../rest/authorization/oauth/rules/must-use-authorization-grant.md).
+Tokens granted through the [authorization code grant flow](../../../../rest/authorization/oauth/rules/must-use-authorization-grant.md) 
+containing the customerId in the `sub`-claim.
 
 An example is provided in the [OAuth2 section](../../../../rest/authorization/README.md#oauth-2-0).
 :::

--- a/api-guidelines/rest/authorization/oauth/README.md
+++ b/api-guidelines/rest/authorization/oauth/README.md
@@ -55,7 +55,7 @@ The JSON content parts of the decoded token look like this:
   "jti": "6f76d949-fad5-4634-ba4f-b7ebf9d32ade", // (unique) ID of the token itself
   "nbf": 1591888481, // epoch time the token must not be accepted before
   "scp": ["otto.read"], // the scope the token is granting access to
-  "sub": "8d0c8242d4654d41858e150f5ef5b3deccd749d3" // (if applicable) the subject of the token, in this case a customer
+  "sub": "69241ea2-327e-47aa-b36c-be61abbc2f30" // (if applicable) the subject of the token, in this case a customer identified by it's customerId
 }
 ```
 


### PR DESCRIPTION
Changelog:

### Update

- Clarified that the `sub` claim of tokens granted through the Authorization Code Grant flow contains the customerId instead of ec-uuid for now, see "SHOULD use customerId to identify customers [R100078](https://api.otto.de/portal/guidelines/r100078)".
