### PR TITLE
fix(rule): refine customerId and oauth2 grants

### DIFF
--- a/api-guidelines/global/json/identifiers/rules/should-use-customerid-to-identify-customers.md
+++ b/api-guidelines/global/json/identifiers/rules/should-use-customerid-to-identify-customers.md
@@ -10,7 +10,7 @@ It replaces the `ec-uuid`.
 In HTTP headers, the `customerId` should be named consistently `Customer-Id`.
 
 ::: warning Important
-Tokens granted through the [authorization code grant flow](../../../../rest/authorization/oauth/rules/must-use-authorization-grant.md) contain the customerId in the `sub`-claim.
+Tokens granted through the [authorization code grant flow](../../../../rest/authorization/oauth/rules/must-use-authorization-grant.md) contain the customerId in the `sub`-claim, thus making the introduction of an additional `Customer-Id` HTTP header obsolete.
 
 An example is provided in the [OAuth2 section](../../../../rest/authorization/README.md#oauth-2-0).
 :::

--- a/api-guidelines/rest/authorization/oauth/rules/must-use-authorization-grant.md
+++ b/api-guidelines/rest/authorization/oauth/rules/must-use-authorization-grant.md
@@ -21,4 +21,7 @@ The OTTO API supports two grant types:
 The [Resource Owner Password Credentials](https://oauth.net/2/grant-types/password/) grant type is not supported.
 :::
 
-The grant type to be used depends on the use cases outlined in the following rules.
+The grant type to be used depends on the use cases outlined in the following rules:
+
+- [Use Authorization Code Grant for confidential clients](should-use-authorization-code-grant-for-confidential-clients.md)
+- [Use Client Credentials Grant for machine to machine authorization](should-use-client-credentials-grant-for-machine-to-machine-authorization.md)


### PR DESCRIPTION
Changelog:

### Update

- Added links to use cases for "MUST use Authorization Grant [R000052](api-guidelines/api-guidelines/rest/authorization/oauth/rules/must-use-authorization-grant.md)".
- Emphasize warning, when not to use customerId as HTTP header for "SHOULD use customerId to identify customers [R100078](api-guidelines/api-guidelines/global/json/identifiers/rules/should-use-customerid-to-identify-customers.md)".
