### PR TITLE
fix: OTTOAPI-510, Dead Link in Event Guidelines - Domain Events reference

### DIFF
--- a/api-guidelines/async/concepts/README.md
+++ b/api-guidelines/async/concepts/README.md
@@ -62,7 +62,7 @@ Examples of domain events:
 
 ::: references
 
-- [What are Domain Events?](https://serialized.io/ddd/domain-event/)
+- [What are Domain Events?](https://web.archive.org/web/20221201162409/https://serialized.io/ddd/domain-event/)
   :::
 
 ## Data events


### PR DESCRIPTION
Changelog:

### Update

- Replaced the dead link to `serialized.io/ddd/domain-event` with its internet archive counterpart. 
