### PR TITLE
chore(docs): Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,10 +101,11 @@ Changelog:
 
 You are welcome to propose a new API guideline.
 Each API guideline requires a unique rule ID, which must be noted in the front matter of the file.
+A rule ID consists of an "R" followed by 6 digits, for example, `R200023`.
 To identify an unused and thus available rule ID, run the following command:
 
 ```bash
-grep -r "^id: " api-guidelines | rev | cut -d" " -f1 | rev | sort | less
+grep -r "^id: R" api-guidelines | rev | cut -d" " -f1 | rev | sort | less
 ```
 
 You can choose any rule ID that is not included in the list.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Each API guideline requires a unique rule ID, which must be noted in the front m
 To identify an unused and thus available rule ID, run the following command:
 
 ```bash
-grep -r "^id: R00" api-guidelines | rev | cut -d" " -f1 | rev | sort | less
+grep -r "^id: " api-guidelines | rev | cut -d" " -f1 | rev | sort | less
 ```
 
 You can choose any rule ID that is not included in the list.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Skip to:
 - [Create a pull request draft](#create-a-pull-request-draft)
 - [Compose a changelog relevant pull request](#compose-a-changelog-relevant-pull-request)
 - [Review a pull request (checklist)](#review-a-pull-request-checklist)
+- [Add a new guideline](#add-a-new-guideline)
 - [Report a bug](#report-a-bug)
 - [Suggest a feature](#suggest-a-feature)
 


### PR DESCRIPTION
- Remove the `R00` prefix matching in the proposed one-liner as it artificially filters out valid matches. We have guideline IDs that start with `R1`, `R2` etc. By only matching for `R00` we filter out many valid IDs that could already be taken.
- Add toc entry that was forgotten in https://github.com/otto-de/api-guidelines/pull/67
- Clarify rule ID structure