### PR TITLE
docs(guidelines): fix E2E test by removing broken links

### DIFF
--- a/api-guidelines/async/compatibility/README.md
+++ b/api-guidelines/async/compatibility/README.md
@@ -4,8 +4,6 @@
 
 [<!--INCLUDE-->Compatible changes](../../global/compatibility/compatible-changes/README.md)
 
-[<!--INCLUDE-->Preview of API changes](../../global/compatibility/preview/README.md)
-
 [<!--INCLUDE-->Deprecation of obsolete API versions and components](../../global/compatibility/deprecation/README.md)
 
 [<!--INCLUDE-->Versioning of incompatible changes](./versioning/README.md)

--- a/api-guidelines/global/compatibility/README.md
+++ b/api-guidelines/global/compatibility/README.md
@@ -4,6 +4,4 @@
 
 [<!--INCLUDE-->Compatible changes](./compatible-changes/README.md)
 
-[<!--INCLUDE-->Preview of API changes](./preview/README.md)
-
 [<!--INCLUDE-->Deprecation of obsolete API versions and components](./deprecation/README.md)

--- a/api-guidelines/rest/compatibility/README.md
+++ b/api-guidelines/rest/compatibility/README.md
@@ -4,8 +4,6 @@
 
 [<!--INCLUDE-->Compatible changes](../../global/compatibility/compatible-changes/README.md)
 
-[<!--INCLUDE-->Preview of API changes](../../global/compatibility/preview/README.md)
-
 [<!--INCLUDE-->Deprecation of obsolete API versions and components](../../global/compatibility/deprecation/README.md)
 
 [<!--INCLUDE-->Client behavior](./client-behavior/README.md)


### PR DESCRIPTION
Fixes https://github.com/otto-ec/techwriting_hub/issues/115 .

Introduced with https://github.com/otto-de/api-guidelines/pull/62/files (readme file has been removed).
