### PR TITLE
chore(docs): restructure and rewrite content in documentation and quality standards chapters

### DIFF
--- a/api-guidelines/global/core-principles/documentation.md
+++ b/api-guidelines/global/core-principles/documentation.md
@@ -2,7 +2,12 @@
 
 Our [quality standards](./quality-standards.md) define all the values that are important to us.
 What's more, we aim to take care of clearly structured documentation, provide our audience with code examples, and make sure they have a great time using our API.
-Here's what that means:
+This includes:
+
+- [Clear structure](#clear-structure)
+- [Code examples](#code-examples)
+- [Consistency and accessibility](#consistency-and-accessibility)
+- [Efficient and refined](#efficient-and-refined)
 
 ## Clear structure
 
@@ -46,14 +51,12 @@ Automated API reference documentation
 
 API reference documentation is created and published automatically, see [MUST provide API specification using OpenAPI](../../rest/contract/openapi/rules/must-provide-api-specification-using-openapi-for-rest-apis.md).
 
-
 ## Consistency and accessibility
 
 - Documentation is provided in American English (EN-US), as US spelling has become the standard in APIs. Also endpoints, properties, and default values are provided in American English.
 - Users can search the documentation.
 - The sidebar is available at all times so that the documentation can be easily browsed. All the endpoints can be accessed via the sidebar.
 - Code examples and explanatory text are visually separated.
-
 
 ## Efficient and refined
 

--- a/api-guidelines/global/core-principles/documentation.md
+++ b/api-guidelines/global/core-principles/documentation.md
@@ -11,29 +11,26 @@ This includes, but is not limited to:
 ## Accessibility and usability
 
 - We provide access to all API endpoints in a central location, some sort of documentation portal at the best, to ensure that users can easily use the API.
-- The documentation is browsable.
-- A well-structured sidebar ensures that the documentation can be navigated so that all the endpoints can be accessed.
+- The documentation is browsable across all available endpoints.
+- A well-structured navigation ensures that the documentation can be navigated.
 - We give users the chance to get in touch with us.
 - All information is easily discoverable, easy to digest, and prepared in a way that users can effectively work with it.
-- We'll be consistent with our tone of voice, terminology, attribute names, API endpoint design, requests and responses, and counting.
+- We are consistent with our tone of voice, terminology, attribute names, API endpoint design, requests and responses, and counting.
 - The layout supports usability accordingly, e.g. with syntax highlighting or multi-column layout.
 
 ## Code examples
 
 - Every endpoint documentation comes with examples and also provides schemas listing the available attributes with explanatory text.
-- Request and response examples that belong to every endpoint documentation have meaningful default values that follow a specific story.
-- Code examples and explanatory text are visually separated.
-- API endpoints and examples are shown in context.
+- Request and response examples that belong to every endpoint documentation have meaningful default values that in the best case follow a specific story.
+- API endpoints and examples are shown in business context.
 - API reference documentation is created and published automatically, see [MUST provide API specification using OpenAPI](../../rest/contract/openapi/rules/must-provide-api-specification-using-openapi-for-rest-apis.md).
 
-## Context and walkthroughs
+## Context
 
 - We give context for API usage such as information about HTTP methods, API operations, request and response headers, versioning, pagination, or errors.
-- With step-by-step walkthroughs we'll cover specific functionality that can be implemented with the API.
-- We cater for experienced users that already have an idea of the endpoints to be used, and at the same time provide the respective structure and information for inexperienced users who need a thorough introduction and/or example use cases.
-- We provide an overview of the most likely tasks to perform with the API.
+- We cater for experienced users that already have an idea of the endpoints to be used and at the same time provide the respective structure and information for inexperienced users who need a thorough introduction, example use cases, or both.
 
 ## Up-to-dateness
 
 - The API is well-documented and up-to-date.  
-- Users can flawlessly integrate and are informed about recent changes.
+- Users can integrate easily and keep up-to-date with the latest API changes.

--- a/api-guidelines/global/core-principles/documentation.md
+++ b/api-guidelines/global/core-principles/documentation.md
@@ -4,54 +4,58 @@ Our [quality standards](./quality-standards.md) define all the values that are i
 What's more, we aim to take care of clearly structured documentation, provide our audience with code examples, and make sure they have a great time using our API.
 Here's what that means:
 
-:::: accordions
-::: accordion Clear structure
-**Usability**
+## Clear structure
+
+Usability
 
 - A user-friendly navigation makes it easy to discover the API and find all relevant information.
 - The sidebar is cleary structured and easy to navigate.
 - API endpoints and examples are shown in context.
 
-**Getting started**
+Getting started
 
 - Basic information is available at one central place, such as info about HTTP methods, API operations, request/response headers, versioning, pagination, or errors.
 - A short and simple guide provides an overview of the most likely tasks to perform with the API.
 - Users can get in touch with us via a contact form.
 
-**Tutorials**  
+Tutorials
+
 With step-by-step walkthroughs we'll cover specific functionality that can be implemented with the API.
 
-**Familiarize users with the API**  
+ Familiarize users with the API
+
 We'll cater for experienced users that already have an idea of the endpoints to be used, and at the same time provide the respective structure and information for inexperienced users who need a thorough introduction and/or example use cases.
 
-**Discoverable and easy to digest**
+Discoverable and easy to digest
 
 - All information is easily discoverable, easy to digest, and prepared in a way that the user can effectively work with it.
 - We'll be consistent with our tone of voice, terminology, attribute names, API endpoint design, requests and responses, and counting.
 - The layout supports accordingly, e.g. with syntax highlighting or multi-column layout.
-  :::
 
-::: accordion Code examples
-**Default values**  
+## Code examples
+
+Default values
+
 Request and response examples that belong to every endpoint documentation have meaningful default values that follow a specific story.
 
-**Code examples and schemas**  
+Code examples and schema
+
 Every endpoint documentation comes with examples and also provides schemas listing the available attributes with explanatory text.
 
-**Automated API reference documentation**  
-API reference documentation is created and published automatically, see [MUST provide API specification using OpenAPI](../../rest/contract/openapi/rules/must-provide-api-specification-using-openapi-for-rest-apis.md).
-:::
+Automated API reference documentation
 
-::: accordion Consistency and accessibility
+API reference documentation is created and published automatically, see [MUST provide API specification using OpenAPI](../../rest/contract/openapi/rules/must-provide-api-specification-using-openapi-for-rest-apis.md).
+
+
+## Consistency and accessibility
 
 - Documentation is provided in American English (EN-US), as US spelling has become the standard in APIs. Also endpoints, properties, and default values are provided in American English.
 - Users can search the documentation.
 - The sidebar is available at all times so that the documentation can be easily browsed. All the endpoints can be accessed via the sidebar.
 - Code examples and explanatory text are visually separated.
-  :::
 
-::: accordion Efficient and refined
+
+## Efficient and refined
+
 The API is well-documented and up-to-date.  
 Users can flawlessly integrate and are informed about recent changes via a revision history.
-:::
-::::

--- a/api-guidelines/global/core-principles/documentation.md
+++ b/api-guidelines/global/core-principles/documentation.md
@@ -1,64 +1,39 @@
 # Documentation
 
-Our [quality standards](./quality-standards.md) define all the values that are important to us.
-What's more, we aim to take care of clearly structured documentation, provide our audience with code examples, and make sure they have a great time using our API.
-This includes:
+We strive to make API implementation a breeze with meaningful, easy-to-understand documentation.
+This includes, but is not limited to:
 
-- [Clear structure](#clear-structure)
+- [Accessibility and usability](#accessibility-and-usability)
 - [Code examples](#code-examples)
-- [Consistency and accessibility](#consistency-and-accessibility)
-- [Efficient and refined](#efficient-and-refined)
+- [Context and walkthroughs](#context-and-walkthroughs)
+- [Up-to-dateness](#up-to-dateness)
 
-## Clear structure
+## Accessibility and usability
 
-Usability
-
-- A user-friendly navigation makes it easy to discover the API and find all relevant information.
-- The sidebar is cleary structured and easy to navigate.
-- API endpoints and examples are shown in context.
-
-Getting started
-
-- Basic information is available at one central place, such as info about HTTP methods, API operations, request/response headers, versioning, pagination, or errors.
-- A short and simple guide provides an overview of the most likely tasks to perform with the API.
-- Users can get in touch with us via a contact form.
-
-Tutorials
-
-With step-by-step walkthroughs we'll cover specific functionality that can be implemented with the API.
-
- Familiarize users with the API
-
-We'll cater for experienced users that already have an idea of the endpoints to be used, and at the same time provide the respective structure and information for inexperienced users who need a thorough introduction and/or example use cases.
-
-Discoverable and easy to digest
-
-- All information is easily discoverable, easy to digest, and prepared in a way that the user can effectively work with it.
+- We provide access to all API endpoints in a central location, some sort of documentation portal at the best, to ensure that users can easily use the API.
+- The documentation is browsable.
+- A well-structured sidebar ensures that the documentation can be navigated so that all the endpoints can be accessed.
+- We give users the chance to get in touch with us.
+- All information is easily discoverable, easy to digest, and prepared in a way that users can effectively work with it.
 - We'll be consistent with our tone of voice, terminology, attribute names, API endpoint design, requests and responses, and counting.
-- The layout supports accordingly, e.g. with syntax highlighting or multi-column layout.
+- The layout supports usability accordingly, e.g. with syntax highlighting or multi-column layout.
 
 ## Code examples
 
-Default values
-
-Request and response examples that belong to every endpoint documentation have meaningful default values that follow a specific story.
-
-Code examples and schema
-
-Every endpoint documentation comes with examples and also provides schemas listing the available attributes with explanatory text.
-
-Automated API reference documentation
-
-API reference documentation is created and published automatically, see [MUST provide API specification using OpenAPI](../../rest/contract/openapi/rules/must-provide-api-specification-using-openapi-for-rest-apis.md).
-
-## Consistency and accessibility
-
-- Documentation is provided in American English (EN-US), as US spelling has become the standard in APIs. Also endpoints, properties, and default values are provided in American English.
-- Users can search the documentation.
-- The sidebar is available at all times so that the documentation can be easily browsed. All the endpoints can be accessed via the sidebar.
+- Every endpoint documentation comes with examples and also provides schemas listing the available attributes with explanatory text.
+- Request and response examples that belong to every endpoint documentation have meaningful default values that follow a specific story.
 - Code examples and explanatory text are visually separated.
+- API endpoints and examples are shown in context.
+- API reference documentation is created and published automatically, see [MUST provide API specification using OpenAPI](../../rest/contract/openapi/rules/must-provide-api-specification-using-openapi-for-rest-apis.md).
 
-## Efficient and refined
+## Context and walkthroughs
 
-The API is well-documented and up-to-date.  
-Users can flawlessly integrate and are informed about recent changes via a revision history.
+- We give context for API usage such as information about HTTP methods, API operations, request and response headers, versioning, pagination, or errors.
+- With step-by-step walkthroughs we'll cover specific functionality that can be implemented with the API.
+- We cater for experienced users that already have an idea of the endpoints to be used, and at the same time provide the respective structure and information for inexperienced users who need a thorough introduction and/or example use cases.
+- We provide an overview of the most likely tasks to perform with the API.
+
+## Up-to-dateness
+
+- The API is well-documented and up-to-date.  
+- Users can flawlessly integrate and are informed about recent changes.

--- a/api-guidelines/global/core-principles/documentation.md
+++ b/api-guidelines/global/core-principles/documentation.md
@@ -22,7 +22,6 @@ This includes, but is not limited to:
 
 - Every endpoint documentation comes with examples and also provides schemas listing the available attributes with explanatory text.
 - Request and response examples that belong to every endpoint documentation have meaningful default values that in the best case follow a specific story.
-- API endpoints and examples are shown in business context.
 - API reference documentation is created and published automatically, see [MUST provide API specification using OpenAPI](../../rest/contract/openapi/rules/must-provide-api-specification-using-openapi-for-rest-apis.md).
 
 ## Context

--- a/api-guidelines/global/core-principles/quality-standards.md
+++ b/api-guidelines/global/core-principles/quality-standards.md
@@ -62,13 +62,13 @@ The bandwidth of possible metrics ranges from purely technical information such 
 
 ## Documentation and support
 
-We help both vendors during development and users of the API with the integration by offering suitable ways of exchange and support.
+We help both the providors during development and the users of the API with the integration by offering suitable ways of exchange and support.
 As the primary resource for explaining the API and its capabilities, documentation must be as accessible to the audience as possible.
 We provide all consumers of the API with comprehensive, professional, up-to-date, and complete information.
 
 ## Communication
 
-We always keep both developers and consumers of the API informed through appropriate channels.
+We always keep both providers and consumers of the API informed through appropriate channels.
 Changes and [deprecations](../../rest/compatibility/README.md#deprecation-of-http-apis) are communicated regularly and actively.
 Therefore, we establish different synchronous and asynchronous communication channels to support developers and consumers.
 
@@ -77,4 +77,4 @@ Therefore, we establish different synchronous and asynchronous communication cha
 API consumers should have fun using the API.
 Our goal is to provide seamless experience to developers when writing software, and to increase their efficiency.
 API consumers should be comfortable using the API in their programming language of choice, finding the functionality they need, as well as using the output.
-We give developers the right tools to help them succeed and aim to provide an as short as possible TTFHW.
+We give developers the right tools to help them succeed and aim to provide an as short as possible Time to First Hello World (TTFHW).

--- a/api-guidelines/global/core-principles/quality-standards.md
+++ b/api-guidelines/global/core-principles/quality-standards.md
@@ -1,8 +1,8 @@
 # Quality standards
 
-As already mentioned, [the scope of the OTTO API](./api-scope.md) ranges between a public and a private API.
+[The scope of the OTTO API](./api-scope.md) ranges between a public and a private API.
 Nevertheless, when it comes to quality, we strive for the standards of a public API.
-If our API needs to be public by tomorrow, external users should then be able to consume our API immediately.
+If the API needs to be public by tomorrow, external users should then be able to consume the API immediately.
 What's more, a consistent understanding of quality standards facilitates the development of further endpoints and the evolution of the OTTO API as a product without unnecessary consultation between all parties involved.
 
 Our understanding of quality covers the following aspects:
@@ -12,35 +12,34 @@ Our understanding of quality covers the following aspects:
 - [Reliability](#reliability)
 - [Security](#security)
 - [Performance](#performance)
-- [Documentation & Support](#documentation--support)
+- [Documentation and support](#documentation-and-support)
 - [Communitcation](#communication)
-- [Developer Experience](#developer-experience)
+- [Developer experience](#developer-experience)
 
 ## Robustness
 
-All implementations of our API follow the [Robustness Principle](https://en.wikipedia.org/wiki/Robustness_principle), as it is essential for the evolution of APIs.
+All implementations of the API follow the [Robustness Principle](https://en.wikipedia.org/wiki/Robustness_principle), as it is essential for the evolution of APIs.
 Future changes to interfaces cannot be anticipated in advance, so aspects such as backward compatibility, loose coupling, and the elimination of the need to synchronize different services are of crucial importance.
 This is especially applicable for microservice environments where dependencies between services should be kept to a minimum.
 
-::: info Info
-Be conservative in what you do, be liberal in what you accept from others.
-:::
+We follow the principle: *Be conservative in what you do, be liberal in what you accept from others.*
 
 ## Consistency
 
-Our API is essentially developed by independent, autonomous functional teams.
+The API is essentially developed by independent, autonomous functional teams.
 However, we strive for a uniform presentation to the outside world.
 The API should give the impression that it was developed by a single team.
 This consistency covers several facets such as documentation, naming conventions, code examples, common data structures, pagination, governance, authentication, and error codes.
 
 ## Reliability
 
-If our API infrastructure is not reliable, consumers will not build trust, and engagement will not increase.
+If the API infrastructure is not reliable, consumers will not build trust, and engagement will not increase.
 API reliability extends beyond uptime.
 We do not limit our evaluation to availability, but also include aspects such as fluctuations in response times or behavior with an increasing number of concurrent API clients.
 
 We avoid unannounced changes and prevent outages to the best of our knowledge.
-When having to choose between consistency (always return even in case of an error) and availability (in doubt return stale content), we prefer availability. Even to the detriment of consistency.
+When having to choose between consistency (always return even in case of an error) and availability (in doubt return stale content), we prefer availability. 
+Even to the detriment of consistency.
 Our endpoints must always return a response, whether the requested operation succeeds or fails.
 
 ## Security
@@ -61,21 +60,21 @@ We also restrict the rate limit to specific resources to prevent misuse.
 We identify and analyze key metrics for different groups of interest.
 The bandwidth of possible metrics ranges from purely technical information such as uptime, latencies, and error rates to business insights such as SDK, version adoption, as well as Time to First Hello World (TTFHW), or API usage growth.
 
-## Documentation & Support
+## Documentation and support
 
-We help both vendors during development and users of our API with the integration by offering suitable ways of exchange and support.
-As the primary resource for explaining our API and its capabilities, documentation must be as accessible to the audience as possible.
-We provide all consumers of our API with comprehensive, professional, up-to-date, and complete information.
+We help both vendors during development and users of the API with the integration by offering suitable ways of exchange and support.
+As the primary resource for explaining the API and its capabilities, documentation must be as accessible to the audience as possible.
+We provide all consumers of the API with comprehensive, professional, up-to-date, and complete information.
 
 ## Communication
 
-We always keep both developers and consumers of our API informed through appropriate channels.
+We always keep both developers and consumers of the API informed through appropriate channels.
 Changes and [deprecations](../../rest/compatibility/README.md#deprecation-of-http-apis) are communicated regularly and actively.
 Therefore, we establish different synchronous and asynchronous communication channels to support developers and consumers.
 
-## Developer Experience
+## Developer experience
 
-API consumers should have fun using our API.
+API consumers should have fun using the API.
 Our goal is to provide seamless experience to developers when writing software, and to increase their efficiency.
-API consumers should be comfortable using our API in their programming language of choice, finding the functionality they need, as well as using the output.
+API consumers should be comfortable using the API in their programming language of choice, finding the functionality they need, as well as using the output.
 We give developers the right tools to help them succeed and aim to provide an as short as possible TTFHW.

--- a/api-guidelines/global/core-principles/quality-standards.md
+++ b/api-guidelines/global/core-principles/quality-standards.md
@@ -7,7 +7,17 @@ What's more, a consistent understanding of quality standards facilitates the dev
 
 Our understanding of quality covers the following aspects:
 
-Robustness
+- [Robustness](#robustness)
+- [Consistency](#consistency)
+- [Reliability](#reliability)
+- [Security](#security)
+- [Performance](#performance)
+- [Documentation & Support](#documentation--support)
+- [Communitcation](#communication)
+- [Developer Experience](#developer-experience)
+
+## Robustness
+
 All implementations of our API follow the [Robustness Principle](https://en.wikipedia.org/wiki/Robustness_principle), as it is essential for the evolution of APIs.
 Future changes to interfaces cannot be anticipated in advance, so aspects such as backward compatibility, loose coupling, and the elimination of the need to synchronize different services are of crucial importance.
 This is especially applicable for microservice environments where dependencies between services should be kept to a minimum.
@@ -16,15 +26,14 @@ This is especially applicable for microservice environments where dependencies b
 Be conservative in what you do, be liberal in what you accept from others.
 :::
 
-Consistency
+## Consistency
 
 Our API is essentially developed by independent, autonomous functional teams.
 However, we strive for a uniform presentation to the outside world.
 The API should give the impression that it was developed by a single team.
 This consistency covers several facets such as documentation, naming conventions, code examples, common data structures, pagination, governance, authentication, and error codes.
 
-
-Reliability
+## Reliability
 
 If our API infrastructure is not reliable, consumers will not build trust, and engagement will not increase.
 API reliability extends beyond uptime.
@@ -34,7 +43,7 @@ We avoid unannounced changes and prevent outages to the best of our knowledge.
 When having to choose between consistency (always return even in case of an error) and availability (in doubt return stale content), we prefer availability. Even to the detriment of consistency.
 Our endpoints must always return a response, whether the requested operation succeeds or fails.
 
-Security
+## Security
 
 Security is not a marginal topic, but an integral part of all software projects, and thus also of APIs.
 
@@ -47,27 +56,26 @@ In addition, we strive to include only the least amount of data necessary to res
 
 We also restrict the rate limit to specific resources to prevent misuse.
 
-Performance
+## Performance
+
 We identify and analyze key metrics for different groups of interest.
 The bandwidth of possible metrics ranges from purely technical information such as uptime, latencies, and error rates to business insights such as SDK, version adoption, as well as Time to First Hello World (TTFHW), or API usage growth.
 
-Documentation & Support
+## Documentation & Support
 
 We help both vendors during development and users of our API with the integration by offering suitable ways of exchange and support.
 As the primary resource for explaining our API and its capabilities, documentation must be as accessible to the audience as possible.
 We provide all consumers of our API with comprehensive, professional, up-to-date, and complete information.
 
-Communication
+## Communication
 
 We always keep both developers and consumers of our API informed through appropriate channels.
 Changes and [deprecations](../../rest/compatibility/README.md#deprecation-of-http-apis) are communicated regularly and actively.
 Therefore, we establish different synchronous and asynchronous communication channels to support developers and consumers.
 
-
-Developer Experience
+## Developer Experience
 
 API consumers should have fun using our API.
 Our goal is to provide seamless experience to developers when writing software, and to increase their efficiency.
 API consumers should be comfortable using our API in their programming language of choice, finding the functionality they need, as well as using the output.
 We give developers the right tools to help them succeed and aim to provide an as short as possible TTFHW.
-

--- a/api-guidelines/global/core-principles/quality-standards.md
+++ b/api-guidelines/global/core-principles/quality-standards.md
@@ -7,8 +7,7 @@ What's more, a consistent understanding of quality standards facilitates the dev
 
 Our understanding of quality covers the following aspects:
 
-::::: accordions
-:::: accordion Robustness
+Robustness
 All implementations of our API follow the [Robustness Principle](https://en.wikipedia.org/wiki/Robustness_principle), as it is essential for the evolution of APIs.
 Future changes to interfaces cannot be anticipated in advance, so aspects such as backward compatibility, loose coupling, and the elimination of the need to synchronize different services are of crucial importance.
 This is especially applicable for microservice environments where dependencies between services should be kept to a minimum.
@@ -16,16 +15,17 @@ This is especially applicable for microservice environments where dependencies b
 ::: info Info
 Be conservative in what you do, be liberal in what you accept from others.
 :::
-::::
 
-:::: accordion Consistency
+Consistency
+
 Our API is essentially developed by independent, autonomous functional teams.
 However, we strive for a uniform presentation to the outside world.
 The API should give the impression that it was developed by a single team.
 This consistency covers several facets such as documentation, naming conventions, code examples, common data structures, pagination, governance, authentication, and error codes.
-::::
 
-:::: accordion Reliability
+
+Reliability
+
 If our API infrastructure is not reliable, consumers will not build trust, and engagement will not increase.
 API reliability extends beyond uptime.
 We do not limit our evaluation to availability, but also include aspects such as fluctuations in response times or behavior with an increasing number of concurrent API clients.
@@ -33,9 +33,9 @@ We do not limit our evaluation to availability, but also include aspects such as
 We avoid unannounced changes and prevent outages to the best of our knowledge.
 When having to choose between consistency (always return even in case of an error) and availability (in doubt return stale content), we prefer availability. Even to the detriment of consistency.
 Our endpoints must always return a response, whether the requested operation succeeds or fails.
-::::
 
-:::: accordion Security
+Security
+
 Security is not a marginal topic, but an integral part of all software projects, and thus also of APIs.
 
 Not all vulnerabilities will be preventable.
@@ -46,30 +46,28 @@ We are conservative in exposing our data and the [Principle of least privilege](
 In addition, we strive to include only the least amount of data necessary to respond to any API call and secure our applications against the [OWASP Top 10 Threats](https://owasp.org/www-project-top-ten/).
 
 We also restrict the rate limit to specific resources to prevent misuse.
-::::
 
-:::: accordion Performance
+Performance
 We identify and analyze key metrics for different groups of interest.
 The bandwidth of possible metrics ranges from purely technical information such as uptime, latencies, and error rates to business insights such as SDK, version adoption, as well as Time to First Hello World (TTFHW), or API usage growth.
-::::
 
-:::: accordion Documentation & Support
+Documentation & Support
+
 We help both vendors during development and users of our API with the integration by offering suitable ways of exchange and support.
 As the primary resource for explaining our API and its capabilities, documentation must be as accessible to the audience as possible.
 We provide all consumers of our API with comprehensive, professional, up-to-date, and complete information.
-::::
 
-:::: accordion Communication
+Communication
 
 We always keep both developers and consumers of our API informed through appropriate channels.
 Changes and [deprecations](../../rest/compatibility/README.md#deprecation-of-http-apis) are communicated regularly and actively.
 Therefore, we establish different synchronous and asynchronous communication channels to support developers and consumers.
-::::
 
-:::: accordion Developer Experience
+
+Developer Experience
+
 API consumers should have fun using our API.
 Our goal is to provide seamless experience to developers when writing software, and to increase their efficiency.
 API consumers should be comfortable using our API in their programming language of choice, finding the functionality they need, as well as using the output.
 We give developers the right tools to help them succeed and aim to provide an as short as possible TTFHW.
-::::
-:::::
+

--- a/api-guidelines/global/core-principles/quality-standards.md
+++ b/api-guidelines/global/core-principles/quality-standards.md
@@ -62,7 +62,7 @@ The bandwidth of possible metrics ranges from purely technical information such 
 
 ## Documentation and support
 
-We help both the providors during development and the users of the API with the integration by offering suitable ways of exchange and support.
+We help both the providers during development and the users of the API with the integration by offering suitable ways of exchange and support.
 As the primary resource for explaining the API and its capabilities, documentation must be as accessible to the audience as possible.
 We provide all consumers of the API with comprehensive, professional, up-to-date, and complete information.
 


### PR DESCRIPTION
**Context**

- Closes [issue 15](https://github.com/otto-ec/techwriting_hub/issues/15)
- Removes accordions to better display the content hidden behind them.
- Uses TOCs to access the different sub-sections.
- Rewrites and trims documentation chapter.

**To reviewers**

- Check if the restructuring helps to better digest and access the provided content.
- Check if rewriting leads to optimization of the chapters.
- Fix any typos or grammar you might find.
- Add anything that you see missing.