### PR TITLE
feat(guidelines): add new rule for sending durable event ids

### DIFF
--- a/api-guidelines/async/semantics/event-structure/rules/must-prepare-consumers-to-consume-events-idempotently.md
+++ b/api-guidelines/async/semantics/event-structure/rules/must-prepare-consumers-to-consume-events-idempotently.md
@@ -40,6 +40,7 @@ As these requirements impose quite a restriction on the producer, a separate [`s
 ::: references
 
 - [MAY provide `sequence` context attribute](../../../format/cloudevents/rules/may-provide-sequence-context-attribute.md)
+- [SHOULD send durable event IDs ](should-send-durable-event-ids.md)
 - [You cannot have exactly-once delivery](https://bravenewgeek.com/you-cannot-have-exactly-once-delivery/)
 - [Exactly-Once Semantics Are Possible: Here’s How Kafka Does It](https://www.confluent.io/de-de/blog/exactly-once-semantics-are-possible-heres-how-apache-kafka-does-it/)
 - [Processing guarantees in kafka](https://medium.com/@andy.bryant/processing-guarantees-in-kafka-12dd2e30be0e)

--- a/api-guidelines/async/semantics/event-structure/rules/should-send-durable-event-ids.md
+++ b/api-guidelines/async/semantics/event-structure/rules/should-send-durable-event-ids.md
@@ -4,6 +4,11 @@ id: R000058
 
 # SHOULD send durable event IDs 
 
-An event is a message containing information about something factual that has happened in the past. An event MUST have an ID that identifies the event. In case of retries or sending over multiple channels the event ID SHOULD be the same. Consumers SHOULD assume that Events with identical source and id are duplicates.
+An event is a message that contains information about something factual that occurred in the past. 
+Each event must have an ID that identifies the event. 
+The event ID should be the same for retries or when sending via multiple channels. Consumers should assume that events with an identical source and ID are duplicates.
 
-See also [cloud event spec](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id)
+::: references
+
+- [id message attribute in cloud event spec](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id)
+  :::

--- a/api-guidelines/async/semantics/event-structure/rules/should-send-durable-event-ids.md
+++ b/api-guidelines/async/semantics/event-structure/rules/should-send-durable-event-ids.md
@@ -1,0 +1,9 @@
+---
+id: R000058
+---
+
+# SHOULD send durable event IDs 
+
+An event is a message containing information about something factual that has happened in the past. An event MUST have an ID that identifies the event. In case of retries or sending over multiple channels the event ID SHOULD be the same. Consumers SHOULD assume that Events with identical source and id are duplicates.
+
+See also [cloud event spec](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id)


### PR DESCRIPTION
Changelog:

### New

- SHOULD send durable event IDs [R000058](https://api.otto.de/portal/guidelines/r000058)
