### PR TITLE
chore(changelog): fix broken and duplicated links

### DIFF
--- a/api-guidelines/async/semantics/event-structure/rules/should-send-durable-event-ids.md
+++ b/api-guidelines/async/semantics/event-structure/rules/should-send-durable-event-ids.md
@@ -1,5 +1,5 @@
 ---
-id: R000058
+id: R000082
 ---
 
 # SHOULD send durable event IDs 

--- a/api-guidelines/rest/http/headers/rules/must-forward-test-header.md
+++ b/api-guidelines/rest/http/headers/rules/must-forward-test-header.md
@@ -4,6 +4,6 @@ id: R000081
 
 # MUST forward `Test` header
 
-An API provider or consumer must include the [`Test` header](./may-use-header.md) from the initial interaction in all subsequent requests and asynchronous events if the original API request or response is marked with a Test header.
+An API provider or consumer must include the [`Test` header](./may-use-test-header.md) from the initial interaction in all subsequent requests and asynchronous events if the original API request or response is marked with a Test header.
 
 This behavior enables downstream API providers and consumers to choose whether they would like to participate in the test.

--- a/changes/changelog.md
+++ b/changes/changelog.md
@@ -4,13 +4,13 @@
 ## 2024-10-07
 ### New
 
-- SHOULD send durable event IDs [R000058](https://api.otto.de/portal/guidelines/r000058)
+- SHOULD send durable event IDs [R000082](https://api.otto.de/portal/guidelines/r000082)
 
 ## 2024-09-18
 ### New
 
-- MAY use Test header [R000080](api-guidelines/rest/http/headers/rules/may-use-test-header.md)
-- MUST forward Test header [R000081](api-guidelines/rest/http/headers/rules/must-forward-test-header.md)
+- MAY use `Test` header [R000080](https://api.otto.de/portal/guidelines/r000080)
+- MUST forward `Test` header [R000081](https://api.otto.de/portal/guidelines/r000081)
 
 ## 2024-03-06
 ### Update


### PR DESCRIPTION
**To reviewers:**

I had a look at the failing E2E tests and figured out the following issues:

- fix broken links
- fix duplicated rule Id as R000058 is already used here https://api.otto.de/portal/guidelines/r000058

Somehow there are some changes in lines that I didn't even touch (all changes after 2024-03-06) and there is no visible change as well. I guess it's a GitHub bug :D