### PR TITLE
fix(dead-link): replace link to internal kafka naming conventions r200006

### DIFF
--- a/api-guidelines/async/kafka/topics/rules/must-follow-kafka-topic-naming-convention.md
+++ b/api-guidelines/async/kafka/topics/rules/must-follow-kafka-topic-naming-convention.md
@@ -47,11 +47,11 @@ event type de.otto.data.products.variation.price.v1 can be found in de.otto.data
 ```
 
 ::: info Info
-This rule only applies to API topics. Topics which are not part of the API must adhere to the [naming conventions for internal topics (internal link)](https://og2.me/Bhl0TB).
+This rule only applies to API topics. Topics which are not part of the API must adhere to the [naming conventions for internal topics (internal link)](https://otto-eg.atlassian.net/wiki/x/xMPmAQ).
 :::
 
 ::: references
 
 - [MUST name events in past tense](../../../format/naming-conventions/rules/must-name-events-in-past-tense.md)
-- [OTTO CoE Confluent Cloud - Topic Naming Conventions (internal link)](https://og2.me/Bhl0TB)
+- [OTTO CoE Confluent Cloud - Topic Naming Conventions (internal link)](https://otto-eg.atlassian.net/wiki/x/xMPmAQ)
   :::


### PR DESCRIPTION

Changelog:

### Update

- Fixed dead link in rule [r200006](portal/guidelines/r200006).