### PR TITLE
chore(changelog): remove changelog entry

### DIFF
--- a/changes/changelog.md
+++ b/changes/changelog.md
@@ -1,10 +1,6 @@
 # Changelog
 
 <!--CHANGELOG-MARKER-->
-## 2024-11-12
-### Update
-
-- Fixed dead link in rule [r200006](portal/guidelines/r200006).
 
 ## 2024-10-07
 ### New


### PR DESCRIPTION
Removed last entry from public changelog as the change is a chore on docs and not relevant on operational level.