### PR TITLE
fix(guidelines): fix links in r200005

### DIFF
--- a/api-guidelines/async/contract/asyncapi/rules/must-provide-api-specification-using-asyncapi-for-asyncrhonous-apis.md
+++ b/api-guidelines/async/contract/asyncapi/rules/must-provide-api-specification-using-asyncapi-for-asyncrhonous-apis.md
@@ -7,5 +7,5 @@ id: R200005
 We use the [AsyncAPI](https://www.asyncapi.com/) specification as a standard to define contracts for asynchronous APIs.
 Any event published for integration with other services must be described using the AsyncAPI specification.
 
-The API description format used must be [AsyncAPI 2.3.0](https://www.asyncapi.com/docs/specifications/v2.3.0) or newer.
-We will extend it according to our needs by using [specification extensions](https://www.asyncapi.com/docs/specifications/v2.3.0#specificationExtensions) in order to describe the functionality that we require.
+The API description format used must be [AsyncAPI 2.3.0](https://v2.asyncapi.com/docs/reference/specification/v2.3.0) or newer.
+We will extend it according to our needs by using [specification extensions](https://v2.asyncapi.com/docs/reference/specification/v2.3.0#specificationExtensions) in order to describe the functionality that we require.


### PR DESCRIPTION
Changelog:

### Update

- Fixed the links to the AsyncAPI docs in "MUST provide API specification using AsyncAPI for asynchronous APIs" [R200005](https://api.otto.de/portal/guidelines/R200005).

