### PR TITLE
fix(rule): update async api rule

### DIFF
--- a/api-guidelines/async/contract/asyncapi/rules/must-provide-api-specification-using-asyncapi-for-asyncrhonous-apis.md
+++ b/api-guidelines/async/contract/asyncapi/rules/must-provide-api-specification-using-asyncapi-for-asyncrhonous-apis.md
@@ -10,4 +10,4 @@ Any event published for integration with other services must be described using 
 The API description format used must be [AsyncAPI 3.0.0](https://www.asyncapi.com/docs/reference/specification/v3.0.0) or newer.
 We extend the specification to our needs by using [specification extensions](https://www.asyncapi.com/docs/reference/specification/v3.0.0#specificationExtensions) in order to describe the functionality that we require.
 
-We publish the specification in [our internal developer portal](https://backstage.live.si.cloud.otto.de/startpage)
+We publish the specification in [our internal developer portal](https://backstage.live.si.cloud.otto.de/startpage).

--- a/api-guidelines/async/contract/asyncapi/rules/must-provide-api-specification-using-asyncapi-for-asyncrhonous-apis.md
+++ b/api-guidelines/async/contract/asyncapi/rules/must-provide-api-specification-using-asyncapi-for-asyncrhonous-apis.md
@@ -7,5 +7,7 @@ id: R200005
 We use the [AsyncAPI](https://www.asyncapi.com/) specification as a standard to define contracts for asynchronous APIs.
 Any event published for integration with other services must be described using the AsyncAPI specification.
 
-The API description format used must be [AsyncAPI 2.3.0](https://v2.asyncapi.com/docs/reference/specification/v2.3.0) or newer.
-We will extend it according to our needs by using [specification extensions](https://v2.asyncapi.com/docs/reference/specification/v2.3.0#specificationExtensions) in order to describe the functionality that we require.
+The API description format used must be [AsyncAPI 3.0.0](https://www.asyncapi.com/docs/reference/specification/v3.0.0) or newer.
+We use extensions to extend the specification to our needs by using [specification extensions](https://www.asyncapi.com/docs/reference/specification/v3.0.0#specificationExtensions) in order to describe the functionality that we require.
+
+We publish the specification in [backstage](https://backstage.live.si.cloud.otto.de/startpage)

--- a/api-guidelines/async/contract/asyncapi/rules/must-provide-api-specification-using-asyncapi-for-asyncrhonous-apis.md
+++ b/api-guidelines/async/contract/asyncapi/rules/must-provide-api-specification-using-asyncapi-for-asyncrhonous-apis.md
@@ -8,6 +8,6 @@ We use the [AsyncAPI](https://www.asyncapi.com/) specification as a standard to 
 Any event published for integration with other services must be described using the AsyncAPI specification.
 
 The API description format used must be [AsyncAPI 3.0.0](https://www.asyncapi.com/docs/reference/specification/v3.0.0) or newer.
-We use extensions to extend the specification to our needs by using [specification extensions](https://www.asyncapi.com/docs/reference/specification/v3.0.0#specificationExtensions) in order to describe the functionality that we require.
+We extend the specification to our needs by using [specification extensions](https://www.asyncapi.com/docs/reference/specification/v3.0.0#specificationExtensions) in order to describe the functionality that we require.
 
-We publish the specification in [backstage](https://backstage.live.si.cloud.otto.de/startpage)
+We publish the specification in [our internal developer portal](https://backstage.live.si.cloud.otto.de/startpage)


### PR DESCRIPTION
Changelog:

### Update

- Changed the required API description format for asynchronous APIs from `2.3.0` to `3.0.0` in "MUST provide API specification using AsyncAPI for asynchronous APIs" [R200005](https://api.otto.de/portal/guidelines/r200005).
- Extended "MUST provide API specification using AsyncAPI for asynchronous APIs" [R200005](https://api.otto.de/portal/guidelines/r200005) by the information that asynchronous APIs must be published in our internal developer portal.