### PR TITLE
docs(changelog): fix broken links

### DIFF
--- a/changes/changelog.md
+++ b/changes/changelog.md
@@ -4,8 +4,8 @@
 ## 2025-06-06
 ### Update
 
-- Establish new folder [decisions](./decisions) to hold future architecture decision records.
-- Moved archive of decisions to [decisions/dev-context](./decisions/dev-context).
+- Established new GitHub repository folder [decisions](https://github.com/otto-de/api-guidelines/tree/main/decisions) to hold future architecture decision records.
+- Moved archive of decisions to GitHub repository folder [decisions/dev-context](https://github.com/otto-de/api-guidelines/tree/main/decisions/dev-context).
 
 ## 2025-03-25
 ### Update

--- a/changes/changelog.md
+++ b/changes/changelog.md
@@ -11,7 +11,7 @@
 ### Update
 
 - Changed the required API description format for asynchronous APIs from `2.3.0` to `3.0.0` in "MUST provide API specification using AsyncAPI for asynchronous APIs" [R200005](https://api.otto.de/portal/guidelines/r200005).
-- Extended "MUST provide API specification using AsyncAPI for asynchronous APIs" [R200005](https://api.otto.de/portal/guidelines/r200005) by the information that asynchronous APIs must be published in our internal developer portal.
+- Extended "MUST provide API specification using AsyncAPI for asynchronous APIs" [R200005](https://api.otto.de/portal/guidelines/r200005) by the information that asynchronous APIs must be published in the internal developer portal.
 
 ## 2025-02-07
 ### Update


### PR DESCRIPTION
Fixes E2E tests and adds more context for links.

I don't know why there are so many "changes" in this PR. All I did was changing content in lines 7-9. You can ignore the rest :)
