### PR TITLE
fix(linter-rules): Handle missing flows property in OpenAPI securitySchemes

### DIFF
--- a/src/linting/rules/define-permissions-with-scope.spec.ts
+++ b/src/linting/rules/define-permissions-with-scope.spec.ts
@@ -173,8 +173,8 @@ openapi: 3.0.3
 
 components:
   securitySchemes:
-    clientCredentials:
-      type: oauth2
+    test:
+      type: http
 `;
 
   const result = await lintFromString({

--- a/src/linting/rules/define-permissions-with-scope.spec.ts
+++ b/src/linting/rules/define-permissions-with-scope.spec.ts
@@ -166,3 +166,37 @@ components:
     ]
   `);
 });
+
+it("should handle missing flows", async () => {
+  const spec = `
+openapi: 3.0.3
+
+components:
+  securitySchemes:
+    clientCredentials:
+      type: oauth2
+`;
+
+  const result = await lintFromString({
+    source: spec,
+    config,
+  });
+
+  removeClutter(result);
+
+  expect(result).toMatchInlineSnapshot(`
+    [
+      {
+        "location": [
+          {
+            "pointer": "#/components/securitySchemes",
+            "reportOnKey": true,
+          },
+        ],
+        "message": "Must define a scope. See https://api.otto.de/portal/guidelines/r000047",
+        "ruleId": "test-rule",
+        "suggest": [],
+      },
+    ]
+  `);
+});

--- a/src/linting/rules/define-permissions-with-scope.ts
+++ b/src/linting/rules/define-permissions-with-scope.ts
@@ -10,7 +10,7 @@ export const DefinePermissionsWithScope: Oas3Rule = () => {
 
   return {
     SecurityScheme({ flows }) {
-      Object.values(flows)
+      Object.values(flows ?? {})
         .flatMap((flow) => Object.keys(flow.scopes ?? {}))
         .forEach((scope) => definedScopes.add(scope));
     },

--- a/src/linting/rules/use-authorization-grant.spec.ts
+++ b/src/linting/rules/use-authorization-grant.spec.ts
@@ -99,8 +99,8 @@ it("should handle missing flows", async () => {
 openapi: 3.0.3
 components:
   securitySchemes:
-    clientCredentials:
-      type: oauth2
+    test:
+      type: http
 `;
 
   const result = await lintFromString({

--- a/src/linting/rules/use-authorization-grant.spec.ts
+++ b/src/linting/rules/use-authorization-grant.spec.ts
@@ -93,3 +93,36 @@ components:
     ]
   `);
 });
+
+it("should handle missing flows", async () => {
+  const spec = `
+openapi: 3.0.3
+components:
+  securitySchemes:
+    clientCredentials:
+      type: oauth2
+`;
+
+  const result = await lintFromString({
+    source: spec,
+    config,
+  });
+
+  removeClutter(result);
+
+  expect(result).toMatchInlineSnapshot(`
+    [
+      {
+        "location": [
+          {
+            "pointer": "#/components/securitySchemes/clientCredentials",
+            "reportOnKey": false,
+          },
+        ],
+        "message": "Must use Authorization Grant. See https://api.otto.de/portal/guidelines/r000052",
+        "ruleId": "test-rule",
+        "suggest": [],
+      },
+    ]
+  `);
+});

--- a/src/linting/rules/use-authorization-grant.spec.ts
+++ b/src/linting/rules/use-authorization-grant.spec.ts
@@ -115,7 +115,7 @@ components:
       {
         "location": [
           {
-            "pointer": "#/components/securitySchemes/clientCredentials",
+            "pointer": "#/components/securitySchemes/test",
             "reportOnKey": false,
           },
         ],

--- a/src/linting/rules/use-authorization-grant.ts
+++ b/src/linting/rules/use-authorization-grant.ts
@@ -17,7 +17,7 @@ export const UseAuthorizationGrant: Oas3Rule = () => {
     },
 
     SecurityScheme({ flows }, { report, location }) {
-      if (!flows.clientCredentials && !flows.authorizationCode) {
+      if (!flows?.clientCredentials && !flows?.authorizationCode) {
         report({
           message,
           location,

--- a/src/vitest.config.ts
+++ b/src/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["src/**/*.spec.ts", "scripts/**/*.spec.ts"],
+    include: ["linting/**/*.spec.ts", "scripts/**/*.spec.ts"],
     reporters: ["verbose"],
     globals: true,
   },


### PR DESCRIPTION
Makes our linter rules more resilient to missing "flows" properties in the securitySchemes components of OpenAPI specifications.

fixes #92 
