### PR TITLE
Avoid digits in camelCase

### DIFF
--- a/api-guidelines/global/json/naming-conventions/rules/should-use-camel-case-for-property-names.md
+++ b/api-guidelines/global/json/naming-conventions/rules/should-use-camel-case-for-property-names.md
@@ -4,7 +4,7 @@ id: R004010
 
 # SHOULD use camelCase for property names
 
-Property names of JSON objects should be formatted in camelCase.
+Property names of JSON objects should be formatted in camelCase. Digits should be avoided.
 
 DO
 

--- a/api-guidelines/rest/resources/naming-conventions/rules/must-use-camelcase-for-query-parameters.md
+++ b/api-guidelines/rest/resources/naming-conventions/rules/must-use-camelcase-for-query-parameters.md
@@ -4,7 +4,7 @@ id: R000022
 
 # MUST use camelCase for query parameters
 
-Use CamelCase to delimit combined words in query parameters.
+Use CamelCase to delimit combined words in query parameters. Digits should be avoided.
 
 DO
 

--- a/decisions/0003-should-avoid-digits-in-camel-case.md
+++ b/decisions/0003-should-avoid-digits-in-camel-case.md
@@ -1,0 +1,66 @@
+# [0003] Avoid digits in camel case
+
+- Status: `accepted`
+- Decided by: <christina.framke@otto.de>, <jens.fischer@otto.de>, <max.edenharter@otto.de>
+- Date: 2025-08-26
+
+## Context
+
+Currently, there several rules in the OTTO API guidelines that refer to using camel case for naming properties, parameters, and other identifiers in APIs.
+The guidelines do not explicitly address the use of digits in camel case names, but our linter does not allow digits in camel case names.
+
+## Options
+
+### Option 1
+
+Allow digits in camel case names, e.g. `item1`, `top100LoveSongs`, as there is no explicit rule against it.
+
+Example:
+
+```yaml
+top100LoveSongs:
+  type: array
+  items:
+    type: string
+    description: The title of a love song.
+  example:
+    - "A Wonderful Song"
+    - "Another Awesome Love Song"
+    - ...
+```
+
+### Option 2
+
+Do not allow digits in camel case names, e.g. `itemOne`, `topOneHundredLoveSongs`, as the linter rule is already in place.
+
+Example:
+
+```yaml
+popularLoveSongs:
+  type: array
+  description: Contains the 100 most popular love songs.
+  items:
+    type: string
+    description: The title of a love song.
+  minItems: 100
+  maxItems: 100
+  example:
+    - "A Wonderful Song"
+    - "Another Awesome Love Song"
+    - ...
+```
+
+## Decision
+
+Option 2 is chosen, as there is no known use case for digits in camel case names, and the OpenAPI specification provides features to describe ranges and array length if needed. The linter rule is already in place and has been used in several APIs without issues. This decision ensures more consistent naming conventions across all APIs.
+
+## Consequences
+
+Existing guidelines referencing camel case names need to be updated to explicitly state that digits should be avoided.
+
+[rule-R100022]: ../api-guidelines/rest/resources/naming-conventions/rules/must-use-camelcase-for-query-parameters.md
+[rule-R104010]: ../api-guidelines/global/json/naming-conventions/rules/should-use-camel-case-for-property-names.md
+
+
+
+

--- a/decisions/0003-should-avoid-digits-in-camel-case.md
+++ b/decisions/0003-should-avoid-digits-in-camel-case.md
@@ -31,7 +31,7 @@ top100LoveSongs:
 
 ### Option 2
 
-Do not allow digits in camel case names, e.g. `itemOne`, `topOneHundredLoveSongs`, as the linter rule is already in place.
+Do not allow digits in camel case names.
 
 Example:
 
@@ -58,8 +58,8 @@ Option 2 is chosen, as there is no known use case for digits in camel case names
 
 Existing guidelines referencing camel case names need to be updated to explicitly state that digits should be avoided.
 
-[rule-R100022]: ../api-guidelines/rest/resources/naming-conventions/rules/must-use-camelcase-for-query-parameters.md
-[rule-R104010]: ../api-guidelines/global/json/naming-conventions/rules/should-use-camel-case-for-property-names.md
+[rule-R000022]: ../api-guidelines/rest/resources/naming-conventions/rules/must-use-camelcase-for-query-parameters.md
+[rule-R004010]: ../api-guidelines/global/json/naming-conventions/rules/should-use-camel-case-for-property-names.md
 
 
 


### PR DESCRIPTION
Changelog:

### Update

- Digits should be avoided when using camelCase notation "MUST use camelCase for query parameters [R000022](./api-guidelines/rest/resources/naming-conventions/rules/must-use-camelcase-for-query-parameters.md)".
- Digits should be avoided when using camelCase notation "SHOULD use camelCase for property names [R004010](./api-guidelines/global/json/naming-conventions/rules/should-use-camel-case-for-property-names.md)".
