### PR TITLE
fix link-relations deep link examples

### DIFF
--- a/api-guidelines/rest/hypermedia/link-relation-types/rules/must-document-link-cardinality.md
+++ b/api-guidelines/rest/hypermedia/link-relation-types/rules/must-document-link-cardinality.md
@@ -13,7 +13,10 @@ The HAL `_links` object holds property names of link relation types, and values 
 ```json
 {
   "_links": {
-    "https://api.otto.de/users/link-relations/author": { "href": "https://api.otto.de/users/42" }
+    "https://api.otto.de/users/link-relations/author": { "href": "https://api.otto.de/users/42" },
+    "https://api.otto.de/portal/link-relations/author": {
+      "href": "https://api.otto.de/portal/link-relations#author"
+    }
   }
 }
 ```
@@ -26,7 +29,10 @@ The HAL `_links` object holds property names of link relation types, and values 
     "https://api.otto.de/products/link-relations/item": [
       { "href": "https://api.otto.de/products/4711" },
       { "href": "https://api.otto.de/products/0815" }
-    ]
+    ],
+    "https://api.otto.de/portal/link-relations/item": {
+      "href": "https://api.otto.de/portal/link-relations#item"
+    }
   }
 }
 ```

--- a/api-guidelines/rest/hypermedia/link-relation-types/rules/must-use-absolute-uris-for-custom-link-relation-types.md
+++ b/api-guidelines/rest/hypermedia/link-relation-types/rules/must-use-absolute-uris-for-custom-link-relation-types.md
@@ -24,7 +24,7 @@ In your APIs, you [must use curied link relation types](./must-use-curied-link-r
 {
   "_links": {
     "https://api.otto.de/checkout/link-relations/checkout-items": {
-      "href": "https://api.otto.de/checkout/items"
+      "href": "https://api.otto.de/portal/link-relations#o_3Acheckout-items"
     }
   }
 }

--- a/api-guidelines/rest/hypermedia/link-relation-types/rules/must-use-curied-link-relation-types.md
+++ b/api-guidelines/rest/hypermedia/link-relation-types/rules/must-use-curied-link-relation-types.md
@@ -18,7 +18,7 @@ Curie objects inside this array must have a templated property `href`.
     "curies": [
       {
         "name": "o",
-        "href": "https://api.otto.de/orders/link-relations/{rel}",
+        "href": "https://api.otto.de/portal/link-relations#{rel}",
         "templated": true
       }
     ]
@@ -35,7 +35,7 @@ Links to a resource with a custom link relation type must be curied using this C
     "curies": [
       {
         "name": "o",
-        "href": "https://api.otto.de/orders/link-relations/{rel}",
+        "href": "https://api.otto.de/portal/link-relations#{rel}",
         "templated": true
       }
     ],
@@ -56,7 +56,7 @@ If the linked resources [can be embedded](../../../resources/embedded-resources/
     "curies": [
       {
         "name": "o",
-        "href": "https://api.otto.de/orders/link-relations/{rel}",
+        "href": "https://api.otto.de/portal/link-relations#{rel}",
         "templated": true
       }
     ],


### PR DESCRIPTION
### What
Fix link-relations examples to use hash-based deep links that are correctly
resolved and expanded by the API Portal.

### Why
The portal anchors and expands link relations via URL fragments.
Path-based examples did not resolve correctly and broke deep linking.

### Example
Old:
`/portal/link-relations/checkout/items`

New:
`/portal/link-relations#o_3Acheckout-items`
