### PR TITLE
fix(guidelines): fix link relations deep links

### DIFF
--- a/api-guidelines/rest/hypermedia/link-relation-types/rules/must-document-link-cardinality.md
+++ b/api-guidelines/rest/hypermedia/link-relation-types/rules/must-document-link-cardinality.md
@@ -13,7 +13,7 @@ The HAL `_links` object holds property names of link relation types, and values 
 ```json
 {
   "_links": {
-    "https://api.otto.de/users/link-relations/author": { "href": "https://api.otto.de/users/42" }
+    "https://api.otto.de/portal/link-relations#author": { "href": "https://api.otto.de/users/42" }
   }
 }
 ```

--- a/api-guidelines/rest/hypermedia/link-relation-types/rules/must-document-link-cardinality.md
+++ b/api-guidelines/rest/hypermedia/link-relation-types/rules/must-document-link-cardinality.md
@@ -13,7 +13,10 @@ The HAL `_links` object holds property names of link relation types, and values 
 ```json
 {
   "_links": {
-    "https://api.otto.de/users/link-relations/author": { "href": "https://api.otto.de/users/42" }
+    "https://api.otto.de/users/link-relations/author": { "href": "https://api.otto.de/users/42" },
+    "https://api.otto.de/portal/link-relations/author": {
+      "href": "https://api.otto.de/portal/link-relations#author"
+    }
   }
 }
 ```
@@ -26,7 +29,10 @@ The HAL `_links` object holds property names of link relation types, and values 
     "https://api.otto.de/products/link-relations/item": [
       { "href": "https://api.otto.de/products/4711" },
       { "href": "https://api.otto.de/products/0815" }
-    ]
+    ],
+    "https://api.otto.de/portal/link-relations/item": {
+      "href": "https://api.otto.de/portal/link-relations#item"
+    }
   }
 }
 ```

--- a/api-guidelines/rest/hypermedia/link-relation-types/rules/must-document-link-cardinality.md
+++ b/api-guidelines/rest/hypermedia/link-relation-types/rules/must-document-link-cardinality.md
@@ -13,10 +13,7 @@ The HAL `_links` object holds property names of link relation types, and values 
 ```json
 {
   "_links": {
-    "https://api.otto.de/users/link-relations/author": { "href": "https://api.otto.de/users/42" },
-    "https://api.otto.de/portal/link-relations/author": {
-      "href": "https://api.otto.de/portal/link-relations#author"
-    }
+    "https://api.otto.de/users/link-relations/author": { "href": "https://api.otto.de/users/42" }
   }
 }
 ```
@@ -26,13 +23,10 @@ The HAL `_links` object holds property names of link relation types, and values 
 ```json
 {
   "_links": {
-    "https://api.otto.de/products/link-relations/item": [
+    "https://api.otto.de/portal/link-relations#item": [
       { "href": "https://api.otto.de/products/4711" },
       { "href": "https://api.otto.de/products/0815" }
-    ],
-    "https://api.otto.de/portal/link-relations/item": {
-      "href": "https://api.otto.de/portal/link-relations#item"
-    }
+    ]
   }
 }
 ```

--- a/api-guidelines/rest/hypermedia/link-relation-types/rules/must-use-absolute-uris-for-custom-link-relation-types.md
+++ b/api-guidelines/rest/hypermedia/link-relation-types/rules/must-use-absolute-uris-for-custom-link-relation-types.md
@@ -14,17 +14,14 @@ The URI used as the link relation type must be treated as an identifier that sho
 While encouraged, it does not need to be resolvable.
 If the URI is resolvable, it should provide human-readable documentation of the link relation type.
 
-The URI should be in the same URL namespace as the API endpoints.
-For example, if all API endpoints are located at `https://api.otto.de/payment/`, the custom link relation URIs should als be located at the same context path (e.g., `https://api.otto.de/payment/link-relations/payment-method`).
-
 Here's an example of an uncuried link relation that serves for demonstration only.
 In your APIs, you [must use curied link relation types](./must-use-curied-link-relation-types.md).
 
 ```json
 {
   "_links": {
-    "https://api.otto.de/checkout/link-relations/checkout-items": {
-      "href": "https://api.otto.de/portal/link-relations#o_3Acheckout-items"
+    "https://api.otto.de/portal/link-relations#checkout-items": {
+      "href": "https://api.otto.de/checkout/items"
     }
   }
 }

--- a/api-guidelines/rest/hypermedia/link-relation-types/rules/must-use-absolute-uris-for-custom-link-relation-types.md
+++ b/api-guidelines/rest/hypermedia/link-relation-types/rules/must-use-absolute-uris-for-custom-link-relation-types.md
@@ -24,7 +24,7 @@ In your APIs, you [must use curied link relation types](./must-use-curied-link-r
 {
   "_links": {
     "https://api.otto.de/checkout/link-relations/checkout-items": {
-      "href": "https://api.otto.de/checkout/items"
+      "href": "https://api.otto.de/portal/link-relations#o_3Acheckout-items"
     }
   }
 }

--- a/api-guidelines/rest/hypermedia/link-relation-types/rules/must-use-curied-link-relation-types.md
+++ b/api-guidelines/rest/hypermedia/link-relation-types/rules/must-use-curied-link-relation-types.md
@@ -18,7 +18,7 @@ Curie objects inside this array must have a templated property `href`.
     "curies": [
       {
         "name": "o",
-        "href": "https://api.otto.de/orders/link-relations/{rel}",
+        "href": "https://api.otto.de/portal/link-relations#{rel}",
         "templated": true
       }
     ]
@@ -35,7 +35,7 @@ Links to a resource with a custom link relation type must be curied using this C
     "curies": [
       {
         "name": "o",
-        "href": "https://api.otto.de/orders/link-relations/{rel}",
+        "href": "https://api.otto.de/portal/link-relations#{rel}",
         "templated": true
       }
     ],
@@ -56,7 +56,7 @@ If the linked resources [can be embedded](../../../resources/embedded-resources/
     "curies": [
       {
         "name": "o",
-        "href": "https://api.otto.de/orders/link-relations/{rel}",
+        "href": "https://api.otto.de/portal/link-relations#{rel}",
         "templated": true
       }
     ],


### PR DESCRIPTION
Changelog:

### Update

- Changed "MUST use absolute URIs for custom link relation types" [R100037](https://api.otto.de/portal/guidelines/r100037) to reflect the current implementation of resolvable link relations without namespaces.
- Updated examples of link relation URLs and templated CURIE links to match the current implementation in the [OTTO Consumer API Portal](https://api.otto.de/portal/). Changes refer to the rules "MUST use absolute URIs for custom link relation types" [R100037](https://api.otto.de/portal/guidelines/r100037), "MUST use curied link relation types" [R100038](https://api.otto.de/portal/guidelines/r100038) as well as "MUST document link cardinality" [R100063](https://api.otto.de/portal/guidelines/r100063).
