### PR TITLE
docs: add UCP protocol exception to scope naming conventions

### DIFF
--- a/api-guidelines/rest/authorization/scopes/rules/shoud-adhere-to-scope-naming-conventions.md
+++ b/api-guidelines/rest/authorization/scopes/rules/shoud-adhere-to-scope-naming-conventions.md
@@ -31,6 +31,11 @@ The following additional rules apply for scope names:
 - Must not include internal product team names as `resource`. <!-- not automatic -->
 - `resource` should be pluralized when referring to collections and singular for singleton resources. <!-- not automatic -->
 
+> **Exception:** Google's UCP protocol requires `:` as a delimiter in predefined
+> scope names (e.g. `ucp:scopes:checkout_session`). Scopes registered exclusively
+> for UCP compliance are permitted to use `:` in their name. This is the only
+> exception to the character restriction above.
+
 :::
 
 ::: accordion Examples


### PR DESCRIPTION
## Summary

Add exception note to scope naming conventions documentation to permit colons (`:`) in scope names when used exclusively for Google's UCP (User Consent Protocol) compliance.

## Changes

- Updated `api-guidelines/rest/authorization/scopes/rules/shoud-adhere-to-scope-naming-conventions.md`
- Added exception block explaining UCP protocol's use of colons as delimiters
- Example scope format: `ucp:scopes:checkout_session`

## Context

Google's UCP protocol requires predefined scopes to use colons as delimiters in their names. This is the only exception to the alphanumeric + `_` or `-` character restriction in the naming conventions rule.

This documentation update accompanies backend (Herakles) and frontend (Olymp) implementations that enable colon support in scope IDs for full UCP compliance.