### PR TITLE
docs(scopes): document UCP protocol exception to naming conventions

### DIFF
--- a/api-guidelines/rest/authorization/scopes/rules/shoud-adhere-to-scope-naming-conventions.md
+++ b/api-guidelines/rest/authorization/scopes/rules/shoud-adhere-to-scope-naming-conventions.md
@@ -31,6 +31,11 @@ The following additional rules apply for scope names:
 - Must not include internal product team names as `resource`. <!-- not automatic -->
 - `resource` should be pluralized when referring to collections and singular for singleton resources. <!-- not automatic -->
 
+> **Exception:** Google's UCP protocol requires `:` as a delimiter in predefined
+> scope names (e.g. `ucp:scopes:checkout_session`). Scopes registered exclusively
+> for UCP compliance are permitted to use `:` in their name. This is the only
+> exception to the character restriction above.
+
 :::
 
 ::: accordion Examples


### PR DESCRIPTION
Adds documentation for the exception to scope naming conventions required
by Google's UCP protocol, which uses colons as delimiters in predefined
scope names.

Changelog:

### Update

- Updated rule "SHOULD adhere to scope naming conventions [R000048](api-guidelines/rest/authorization/scopes/rules/shoud-adhere-to-scope-naming-conventions.md)".
- Added exception for Google's UCP protocol scope format (e.g. `ucp:scopes:checkout_session`).